### PR TITLE
Add note about starting svadilfari before logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ def deps do
     {:svadilfari, "~> 0.1"}
   ]
 end
+
+# Also make sure it starts before :logger because logger uses it now
+def application do
+  [
+    ...
+    extra_applications: [..., :svadilfari, :logger, ...]
+    ...
+  ]
 ```
 
 Configure some parameters:


### PR DESCRIPTION
Sometimes logger manages to log things before svadilfari has been started. Making sure :svadilfari is started before :logger avoids this.